### PR TITLE
Simplified local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 IMAGE=onmetal/documentation
 
-start-local-docker:
+start:
 	docker build -t $(IMAGE) .
 	docker run -p 8000:8000 -v `pwd`/:/docs $(IMAGE)
 .PHONY: setup-local-docker
 
-clean-stopped-docker-container:
+clean:
 	docker container prune --force --filter "label=project=onmetal_documentation"
 .PHONY: clean-old-docker-container

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# onmetal
+# Gardener on Metal Documentation
 
-OnMetal Documentation Project
+This project is the main entrypoint for the Gardener on Metal documentation.
 
 ## Local development
 
@@ -9,13 +9,13 @@ to start a Docker container using the current repository content. Hot-reloading 
 so there is no need to restart the container after you made some changes.
 
 ```bash
-make start-local-docker
+make start
 ```
 
 Stopped container instances can be cleaned up via
 
 ```bash
-make clean-stopped-docker-container
+make clean
 ```
 
 ## Contribution guide


### PR DESCRIPTION
You can now use `make start` and `make clean` to run and cleanup the local development setup.