### PR TITLE
Use multi arch docker image for mkdocs-material

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:7.2.6
+FROM ghcr.io/afritzler/mkdocs-material:7.2.7 
 
 LABEL project=onmetal_documentation
 


### PR DESCRIPTION
Use multi arch docker image for mkdocs-material to support Apple M1